### PR TITLE
Group all dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,30 @@ updates:
       pydantic-deps:
         patterns:
           - "pydantic*"
+      pip-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
**What I did**

Group dependabot for everything. This means we need to run fewer CI tests, and have fewer PRs to review and accept. Also, the CI will catch any interactions between updates that might break something

I kept pydantic in its own group because it tends to break with pydantic-core: This way we can specifically exclude a pydantic-core version there, without touching any other dependencies. This is definitely a compromise.

dependabot will add a dependency to the first matching group. This will not include pydantic* twice
