### PR TITLE
add missing partial_deposit/arg_withdrawal_address/mismatch text

### DIFF
--- a/ethstaker_deposit/intl/en/cli/partial_deposit.json
+++ b/ethstaker_deposit/intl/en/cli/partial_deposit.json
@@ -26,7 +26,8 @@
       "arg_withdrawal_address": {
           "help": "The withdrawal address of the validator. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command.",
           "confirm": "Repeat the withdrawal address for confirmation.",
-          "prompt": "Please enter the withdrawal address. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command."
+          "prompt": "Please enter the withdrawal address. If you wish to create a validator with 0x00 credentials use the new-mnemonic or existing-mnemonic command.",
+          "mismatch": "Error: the two entered addresses do not match. Please type again."
       },
       "arg_compounding": {
           "help": "Generates compounding validators with 0x02 withdrawal credentials for a 2048 ETH maximum effective balance or generate regular validators with 0x01 withdrawal credentials for a 32 ETH maximum effective balance. This feature is only supported on networks that have undergone the Pectra fork.",


### PR DESCRIPTION
It turns out there's a missing partial_deposit/arg_withdrawal_address/mismatch text. If the lambda at `ethstaker_deposit/cli/partial_deposit.py:118` is called, an exception is thrown.

```python
@jit_option(
    callback=captive_prompt_callback(
        lambda address, _: validate_withdrawal_address(None, None, address, True),
        lambda: load_text(['arg_withdrawal_address', 'prompt'], func=FUNC_NAME),
        lambda: load_text(['arg_withdrawal_address', 'confirm'], func=FUNC_NAME),
HERE--> lambda: load_text(['arg_withdrawal_address', 'mismatch'], func=FUNC_NAME),
        prompt_if=prompt_if_none,
    ),
    help=lambda: load_text(['arg_withdrawal_address', 'help'], func=FUNC_NAME),
    param_decls=['--withdrawal_address', '--execution_address', '--eth1_withdrawal_credentials'],
    prompt=False,  # the callback handles the prompt
)
```


**Related issue**

Here's how to reproduce the problem:
1. Create a keystore file.
2. Run `deposit.sh partial-deposit`.
3. When asked to `Repeat the withdrawal address for confirmation`, enter a valid but different address.
4.

```
Traceback (most recent call last):
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/utils/intl.py", line 31, in _get_from_dict
    raise ValidationError('Incomplete')
ethstaker_deposit.exceptions.ValidationError: Incomplete

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/utils/intl.py", line 73, in load_text
    return _get_from_dict(text_dict, [func] + params)
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/utils/intl.py", line 36, in _get_from_dict
    raise KeyError('The provided params (%s) were incomplete.' % mapList)
KeyError: "The provided params (['partial_deposit', 'arg_withdrawal_address', 'mismatch']) were incomplete."

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/__main__.py", line 4, in <module>
    deposit.run()
    ~~~~~~~~~~~^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/deposit.py", line 127, in run
    cli()
    ~~~^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 1695, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 949, in make_context
    self.parse_args(ctx, args)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 1417, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 2403, in handle_parse_result
    value = self.process_value(ctx, value)
  File "/home/d/dev/eth/ethstaker-deposit-cli/env/lib/python3.13/site-packages/click/core.py", line 2365, in process_value
    value = self.callback(ctx, self, value)
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/utils/click.py", line 194, in callback
    raise ValidationError(confirmation_mismatch_msg())
                          ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/cli/partial_deposit.py", line 118, in <lambda>
    lambda: load_text(['arg_withdrawal_address', 'mismatch'], func=FUNC_NAME),
            ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/utils/intl.py", line 77, in load_text
    raise KeyError('%s not in %s file' % ([func] + params, json_path))
KeyError: "['partial_deposit', 'arg_withdrawal_address', 'mismatch'] not in /home/d/dev/eth/ethstaker-deposit-cli/ethstaker_deposit/intl/en/cli/partial_deposit.json file"
```


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

lol
![image](https://github.com/user-attachments/assets/7fae4f5a-0978-426f-8e93-6cc0634bd278)
