### PR TITLE
Use macos15-intel for macOS x64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-latest, windows-latest, windows-11-arm]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-15-intel, macos-latest, windows-latest, windows-11-arm]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest, windows-11-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest, windows-11-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: windows-11-arm


### PR DESCRIPTION
**What I did**

Replace `macos-13` with `macos-15-intel`

https://github.com/actions/runner-images/issues/13045

We will discontinue macOS x64 support no later than August 2027, and our next release should mention that in release notes

"GitHub Actions is starting the deprecation process for macOS 13 and macOS 13 arm64. For users that require the x86_64 (Intel) environment, we are introducing a new label to migrate to: macos-15-intel. The new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions."
