### PR TITLE
generate-mnemonic docs don't show as new-mnemonic

### DIFF
--- a/docs/src/generate_mnemonic.md
+++ b/docs/src/generate_mnemonic.md
@@ -1,9 +1,12 @@
-# new-mnemonic
+# generate-mnemonic
 
 {{#include ./snippet/warning_message.md}}
 
 ## Description
-Generates a new random BIP-39 mnemonic. If you also want to create your validator keystore and deposit files, you should be using the **[new-mnemonic](new_mnemonic.md)** or the **[existing-mnemonic](existing_mnemonic.md)** command instead. This command can be used as part of some automation where you can first generate your mnemonic with `generate-mnemonic` and generate the validator keystore and deposit files with `existing-mnemonic` without any interactive prompt.
+
+Generates a new random BIP-39 mnemonic. If you also want to create your validator keystore and deposit files, you should be using the **[new-mnemonic](new_mnemonic.md)**
+or the **[existing-mnemonic](existing_mnemonic.md)** command instead. This command can be used as part of some automation where you can first generate your mnemonic with
+`generate-mnemonic` and generate the validator keystore and deposit files with `existing-mnemonic` without any interactive prompt.
 
 ## Optional Arguments
 


### PR DESCRIPTION
**What I did**

The `generate-mnemonic` docs had a header of `new-mnemonic`. Fixed that, and also introduced line breaks
