### PR TITLE
Remove Holesky, replace with Hoodi

### DIFF
--- a/docs/src/bls_to_execution_change_file.md
+++ b/docs/src/bls_to_execution_change_file.md
@@ -19,9 +19,9 @@ If you have access to a beacon node client running on your target network, you c
     },
     "signature":"0xa1e47e6b1fdf4dd5f1dd3ddb3d47d2dcf446d096d49d90afef06a38dc02fba6b4d16d1dc1184c791e54666dabb8bdedd0660bc9bb3bc5d0e592eaf5f0c978cca4fcafe4037672940d6f1a44d2a33503c30cb98ca695979b1de9e321a8a694bc2",
     "metadata":{
-      "network_name":"holesky",
+      "network_name":"hoodi",
       "genesis_validators_root":"0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
-      "deposit_cli_version":"0.1.4-dev"
+      "deposit_cli_version":"1.2.2"
     }
   }
 ]

--- a/docs/src/deposit_data_file.md
+++ b/docs/src/deposit_data_file.md
@@ -41,8 +41,8 @@ Each deposit from the list will contain this structure:
     "deposit_message_root":"f9bdb1e800b8f9f0db98c77271745e3c6140f18bf420543bda84fa92c393ddc7",
     "deposit_data_root":"7cda08cd57c303f8af720b10a0852408bc31e015cb552f0029fc1024b8a1d615",
     "fork_version":"01017000",
-    "network_name":"holesky",
-    "deposit_cli_version":"2.7.0"
+    "network_name":"hoodi",
+    "deposit_cli_version":"1.2.2"
   },
   {
     "pubkey":"86ee0b826d7d5262324ace2fba4ed5f09a1cbef80552e3d945279f19bc4118a98e9a93257eb4c7731ccc10c19835d24f",
@@ -52,8 +52,8 @@ Each deposit from the list will contain this structure:
     "deposit_message_root":"99dbb2392fef277c15e710ca0ead058c024adce15f9e8f369bbaea939c0009ed",
     "deposit_data_root":"0fcb16fdb536b00a037a3ccde67187d21abfb726d677e40709ae6910d44377a5",
     "fork_version":"01017000",
-    "network_name":"holesky",
-    "deposit_cli_version":"2.7.0"
+    "network_name":"hoodi",
+    "deposit_cli_version":"1.2.2"
   }
 ]
 ```

--- a/docs/src/existing_mnemonic.md
+++ b/docs/src/existing_mnemonic.md
@@ -7,7 +7,7 @@ Uses an existing BIP-39 mnemonic phrase for key generation.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/exit_transaction_keystore.md
+++ b/docs/src/exit_transaction_keystore.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a keystore file.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to exit.
 

--- a/docs/src/exit_transaction_mnemonic.md
+++ b/docs/src/exit_transaction_mnemonic.md
@@ -7,7 +7,7 @@ Creates an exit transaction using a mnemonic phrase.
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used during key generation. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change.md
+++ b/docs/src/generate_bls_to_execution_change.md
@@ -9,7 +9,7 @@ Generates a BLS to execution address change message. This is used to add a withd
 
 - **`--bls_to_execution_changes_folder`**: The path to store the change JSON file.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--mnemonic`**: The mnemonic you used to create withdrawal credentials. <span class="warning"></span>
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -11,7 +11,7 @@ Signs a withdrawal credential update message using the provided keystore. This s
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
 

--- a/docs/src/new_mnemonic.md
+++ b/docs/src/new_mnemonic.md
@@ -9,7 +9,7 @@ Generates a new random BIP-39 mnemonic along with validator keystore and deposit
 
 - **`--mnemonic_language`**: The language of the BIP-39 mnemonic. Options are: 'chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'portuguese', 'spanish'.
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--num_validators`**: Number of validators to create.
 

--- a/docs/src/other_install_options.md
+++ b/docs/src/other_install_options.md
@@ -129,10 +129,10 @@
     docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
     ```
 
-    Example for 1 validator on the [Holesky testnet](https://holesky.launchpad.ethereum.org/) using english:
+    Example for 1 validator on the [Hoodi testnet](https://hoodi.launchpad.ethereum.org/) using english:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ghcr.io/ethstaker/ethstaker-deposit-cli:latest new-mnemonic --num_validators=1 --mnemonic_language=english --chain=hoodi
     ```
 
 ### Option 4. Use local docker image
@@ -159,10 +159,10 @@
     docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli new-mnemonic --num_validators=<NUM_VALIDATORS> --mnemonic_language=english
     ```
 
-    Example for 1 validator on the [Holesky testnet](https://holesky.launchpad.ethereum.org/) using english:
+    Example for 1 validator on the [Hoodi testnet](https://hoodi.launchpad.ethereum.org/) using english:
 
     ```sh
-    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky
+    docker run -it --rm -v $(pwd)/validator_keys:/app/validator_keys ethstaker/ethstaker-deposit-cli new-mnemonic --num_validators=1 --mnemonic_language=english --chain=hoodi
     ```
 
 ----

--- a/docs/src/partial_deposit.md
+++ b/docs/src/partial_deposit.md
@@ -8,7 +8,7 @@ If you wish to create a validator with 0x00 credentials, you must use the **[new
 
 ## Optional Arguments
 
-- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'holesky', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'sepolia', 'hoodi', 'ephemery', 'gnosis', or 'chiado'.
 
 - **`--keystore`**: The keystore file associating with the validator you wish to deposit to.
 

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -28,7 +28,6 @@ class BaseChainSetting(NamedTuple):
 
 MAINNET = 'mainnet'
 SEPOLIA = 'sepolia'
-HOLESKY = 'holesky'
 HOODI = 'hoodi'
 EPHEMERY = 'ephemery'
 GNOSIS = 'gnosis'
@@ -46,12 +45,6 @@ SepoliaSetting = BaseChainSetting(
     GENESIS_FORK_VERSION=bytes.fromhex('90000069'),
     EXIT_FORK_VERSION=bytes.fromhex('90000072'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078'))
-# Holesky setting
-HoleskySetting = BaseChainSetting(
-    NETWORK_NAME=HOLESKY,
-    GENESIS_FORK_VERSION=bytes.fromhex('01017000'),
-    EXIT_FORK_VERSION=bytes.fromhex('04017000'),
-    GENESIS_VALIDATORS_ROOT=bytes.fromhex('9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1'))
 # Hoodi setting
 HoodiSetting = BaseChainSetting(
     NETWORK_NAME=HOODI,
@@ -91,7 +84,6 @@ ChiadoSetting = BaseChainSetting(
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     SEPOLIA: SepoliaSetting,
-    HOLESKY: HoleskySetting,
     HOODI: HoodiSetting,
     EPHEMERY: EphemerySetting,
     GNOSIS: GnosisSetting,

--- a/tests/test_cli/test_existing_mnemonic.py
+++ b/tests/test_cli/test_existing_mnemonic.py
@@ -530,10 +530,10 @@ def test_existing_mnemonic_custom_testnet() -> None:
         os.mkdir(my_folder_path)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
 
     devnet_chain_setting = json.dumps(devnet_chain)
@@ -593,7 +593,7 @@ def test_existing_mnemonic_multiple_languages() -> None:
         '--language', 'english',
         '--ignore_connectivity',
         'existing-mnemonic',
-        '--chain', 'holesky',
+        '--chain', 'hoodi',
         '--withdrawal_address', '',
         '--folder', my_folder_path,
         '--mnemonic_password', 'TREZOR',
@@ -638,7 +638,7 @@ def test_existing_mnemonic_multiple_languages_argument() -> None:
         '--language', 'english',
         '--ignore_connectivity',
         'existing-mnemonic',
-        '--chain', 'holesky',
+        '--chain', 'hoodi',
         '--withdrawal_address', '',
         '--folder', my_folder_path,
         '--mnemonic_language', '简体中文',

--- a/tests/test_cli/test_exit_transaction_keystore.py
+++ b/tests/test_cli/test_exit_transaction_keystore.py
@@ -309,10 +309,10 @@ def test_exit_transaction_keystore_custom_testnet() -> None:
 
     # Shared parameters
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     devnet_chain_setting = json.dumps(devnet_chain)
     keystore_password = 'solo-stakers'

--- a/tests/test_cli/test_exit_transaction_mnemonic.py
+++ b/tests/test_cli/test_exit_transaction_mnemonic.py
@@ -119,12 +119,12 @@ async def test_exit_transaction_mnemonic_multiple() -> None:
     'chain, mnemonic, start_index, indices, epoch, assertion',
     [
         ('asdf', "aban aban aban aban aban aban aban aban aban aban aban abou", 0, 0, 0, 1),
-        ('holesky', "this is not valid", 0, 0, 0, 1),
+        ('hoodi', "this is not valid", 0, 0, 0, 1),
         # 2 exit code due to thrown ValidationError
-        ('holesky', "aban aban aban aban aban aban aban aban aban aban aban abou", "a", 0, 0, 2),
-        ('holesky', "aban aban aban aban aban aban aban aban aban aban aban abou", 0, "b", 0, 1),
+        ('hoodi', "aban aban aban aban aban aban aban aban aban aban aban abou", "a", 0, 0, 2),
+        ('hoodi', "aban aban aban aban aban aban aban aban aban aban aban abou", 0, "b", 0, 1),
         # 2 exit code due to thrown ValidationError
-        ('holesky', "aban aban aban aban aban aban aban aban aban aban aban abou", 0, 0, "c", 2),
+        ('hoodi', "aban aban aban aban aban aban aban aban aban aban aban abou", 0, 0, "c", 2),
     ]
 )
 def test_exit_mnemonic_invalid_params(chain, mnemonic, start_index, indices, epoch, assertion) -> None:
@@ -160,10 +160,10 @@ def test_exit_transaction_mnemonic_custom_network() -> None:
         os.mkdir(my_folder_path)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     devnet_chain_setting = json.dumps(devnet_chain)
 

--- a/tests/test_cli/test_generate_bls_to_execution_change.py
+++ b/tests/test_cli/test_generate_bls_to_execution_change.py
@@ -128,10 +128,10 @@ def test_bls_change_custom_testnet() -> None:
     my_folder_path = prepare_testing_folder(os)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
 
     devnet_chain_setting = json.dumps(devnet_chain)

--- a/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
+++ b/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
@@ -296,10 +296,10 @@ def test_bls_change_keystore_custom_testnet() -> None:
         os.mkdir(changes_folder_path)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
 
     devnet_chain_setting = json.dumps(devnet_chain)
@@ -361,15 +361,15 @@ def test_invalid_custom_testnet() -> None:
         os.mkdir(changes_folder_path)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
+        "network_name": "hoodicopy",
         "exit_fork_version": "04017000",
     }
 
     correct_devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
 
     devnet_chain_setting = json.dumps(devnet_chain)

--- a/tests/test_cli/test_new_mnemonic.py
+++ b/tests/test_cli/test_new_mnemonic.py
@@ -1075,10 +1075,10 @@ def test_new_mnemonic_custom_testnet(monkeypatch) -> None:
         os.mkdir(my_folder_path)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
 
     devnet_chain_setting = json.dumps(devnet_chain)

--- a/tests/test_cli/test_partial_deposit.py
+++ b/tests/test_cli/test_partial_deposit.py
@@ -444,10 +444,10 @@ def test_partial_deposit_custom_network(amount: str) -> None:
         os.mkdir(partial_deposit_folder)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     devnet_chain_setting = json.dumps(devnet_chain)
 
@@ -500,10 +500,10 @@ def test_invalid_custom_network_json() -> None:
         os.mkdir(partial_deposit_folder)
 
     devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     devnet_chain_setting = 'abcd'
 

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -167,7 +167,7 @@ invalid_signature = (
         # valid
         ('mainnet', 0, 0, valid_pubkey, valid_signature, True),
         # bad chain
-        ('holesky', 0, 0, valid_pubkey, valid_signature, False),
+        ('hoodi', 0, 0, valid_pubkey, valid_signature, False),
         # bad epoch
         ('mainnet', 1, 0, valid_pubkey, valid_signature, False),
         # bad validator_index
@@ -189,18 +189,18 @@ def test_validate_signed_exit(
 def test_validate_devnet_chain_setting_json() -> None:
     # Correct devnet chain value
     corret_devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     assert validate_devnet_chain_setting_json(json.dumps(corret_devnet_chain)) is True
 
     # Invalid devnet chain value missing 1 required key
     missing_1_key_devnet_chain = {
-        "network_name": "holeskycopy",
+        "network_name": "hoodicopy",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     with pytest.raises(ValidationError):
         assert validate_devnet_chain_setting_json(json.dumps(missing_1_key_devnet_chain)) is False
@@ -215,28 +215,28 @@ def test_validate_devnet_chain_setting_json() -> None:
 
     # Correct devnet chain value missing 1 optional key
     correct_missing_genesis_validator_root_devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000"
     }
     assert validate_devnet_chain_setting_json(json.dumps(correct_missing_genesis_validator_root_devnet_chain)) is True
 
     # Invalid devnet chain value with wrong fourth key name
     invalid_fourth_key_devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
+        "genesis_validator": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
     }
     with pytest.raises(ValidationError):
         assert validate_devnet_chain_setting_json(json.dumps(invalid_fourth_key_devnet_chain)) is False
 
     # Invalid devnet chain value with too many keys
     invalid_too_many_keys_devnet_chain = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f",
         "multiplier": "1",
         "min_deposit_amount": "1",
         "more_key": "value"
@@ -253,19 +253,19 @@ def test_validate_devnet_chain_setting_json() -> None:
         assert validate_devnet_chain_setting_json('[1, 2, 3]') is False
 
     correct_devnet_chain_with_multiplier = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f",
         "multiplier": "1"
     }
     assert validate_devnet_chain_setting_json(json.dumps(correct_devnet_chain_with_multiplier)) is True
 
     correct_devnet_chain_with_multiplier_and_min_deposit_amount = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f",
         "multiplier": "1",
         "min_deposit_amount": "1"
     }
@@ -273,10 +273,10 @@ def test_validate_devnet_chain_setting_json() -> None:
         json.dumps(correct_devnet_chain_with_multiplier_and_min_deposit_amount)) is True
 
     invalid_devnet_chain_with_min_deposit_amount_and_wrong_key = {
-        "network_name": "holeskycopy",
-        "genesis_fork_version": "01017000",
+        "network_name": "hoodicopy",
+        "genesis_fork_version": "10000910",
         "exit_fork_version": "04017000",
-        "genesis_validator_root": "9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
+        "genesis_validator_root": "212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f",
         "min_deposit_amount": "1",
         "compounding": "true"
     }


### PR DESCRIPTION
**What I did**

Remove support for Holesky network. Change all tests to use Hoodi and copies of Hoodi

Hoodi parameters are at https://github.com/eth-clients/hoodi
