### PR TITLE
Dependabot updates uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,11 @@ updates:
       actions-deps:
         patterns:
           - "*"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      npm-deps:
+      uv-deps:
         patterns:
           - "*"


### PR DESCRIPTION
**What I did**

Teach dependabot to update `uv.lock`

We never had an `npm` run because we don't use `npm`, remove that section
