### PR TITLE
Dependabot only updates patch version for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
+    allow:
+      - update-types: "version-update:semver-patch"
     cooldown:
       default-days: 7
     directory: "/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This image is from python:3.14.7-slim-trixie (https://hub.docker.com/_/python)
+# This image is from python:3.14-slim-trixie (https://hub.docker.com/_/python)
 FROM python@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4
 
 WORKDIR /app


### PR DESCRIPTION
**What I did**

`Dockerfile` uses Python 3.14. When 3.15 is out, I don't want dependabot upgrading to that. Restrict to patch version, which will bring in new releases of 3.14
