### PR TITLE
Restore pydantic-deps group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      pydantic-deps:
+        patterns:
+          - "pydantic*"
       uv-deps:
         patterns:
           - "*"


### PR DESCRIPTION
**What I did**

Pydantic/pydantic-core remains a special case
