### PR TITLE
Publish library to test PyPi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,49 @@
+name: ci-pypi
+run-name: ${{ github.actor }} is publishing ${{ github.ref_name }} to PyPI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.14"
+          cache: 'pip'
+
+      - name: Verify VERSION file matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION="$(tr -d '[:space:]' < ethstaker_deposit/VERSION)"
+          echo "Tag version:  ${TAG_VERSION}"
+          echo "VERSION file: ${FILE_VERSION}"
+          if [[ "${FILE_VERSION}" != "${TAG_VERSION}" ]]; then
+            echo "::error::ethstaker_deposit/VERSION (${FILE_VERSION}) does not match pushed tag (${TAG_VERSION}). Refusing to publish to PyPI."
+            exit 1
+          fi
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        # TODO: this is temporarily pointed at TestPyPI to validate the pipeline (starting with the v1.3.1 tag).
+        # Remove the repository-url line below to switch to production PyPI for the v1.4.0 release.
+        # This pinned action came from pypa/gh-action-pypi-publish@v1.14.2, releases can be found on https://github.com/pypa/gh-action-pypi-publish/releases
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/

--- a/docs/src/release_process.md
+++ b/docs/src/release_process.md
@@ -4,18 +4,19 @@ This document is meant as a guide on how to perform and publish a new release ve
 
 1. Make sure all the tests from the latest [ci-runner workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/runner.yml) on the latest commit of the main branch are completed. Make sure all tests are passing on all the supported platforms.
 2. Determine a new version number. Version numbers should adhere to [Semantic Versioning](https://semver.org/). For any official release, it should include a major, a minor and a patch identifier like `1.0.0`.
-3. Update `ethstaker_deposit/VERSION`'s content with the new version number. Commit this change to the main branch of the main repository.
+3. Update `ethstaker_deposit/VERSION`'s content with the new version number, with no `dev` (or other) suffix. Commit this change to the main branch of the main repository. This is a hard requirement: [the ci-pypi workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/pypi.yml) (see step 6 below) refuses to publish to PyPI if this file doesn't exactly match the tag pushed in the next step.
 4. Add a tag to the main repository for this changed version commit above. The name of this tag should be a string starting with `v` concatenated with the version number. With git, the main repository cloned and the commit above being the head, it can look like this:
 ```console
 git tag -a -m 'Version 1.0.0' v1.0.0
 git push origin v1.0.0
 ```
 5. Wait for all the build assets and the draft release to be created by [the ci-build workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/build.yml).
-6. Open the draft release and fill in the different sections correctly.
-7. If this is not a production release, check the *Set as a pre-release* checkbox.
-8. Click the *Publish release* button.
-9. Determine a new dev version number. You can try to guess the next version number to the best of your ability. This will always be subject to change. Add a `dev` identifier to the version number to clearly indicate this is a dev version number.
-10. Update `ethstaker_deposit/VERSION`'s content with a new dev version number. Commit this change to the main branch.
+6. The tag push also triggers [the ci-pypi workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/pypi.yml), which builds and publishes the package to PyPI. This workflow waits for approval against the `pypi` environment's protection rule — open the workflow run in the Actions tab and approve the pending deployment to let it proceed.
+7. Open the draft release and fill in the different sections correctly.
+8. If this is not a production release, check the *Set as a pre-release* checkbox.
+9. Click the *Publish release* button.
+10. Determine a new dev version number. You can try to guess the next version number to the best of your ability. This will always be subject to change. Add a `dev` identifier to the version number to clearly indicate this is a dev version number.
+11. Update `ethstaker_deposit/VERSION`'s content with a new dev version number. Commit this change to the main branch.
 
 ## Release Notes Template
 


### PR DESCRIPTION
**What I did**

Create a publish step as `ethstaker_deposit` into PyPi. In this commit, that is only to the PyPi test environment, for the `v1.3.1` pre-release. Once we are happy it works well, that can be changed to production in time for the `v1.4.0` release.

Created by Claude Sonnet 5
