### PR TITLE
Fix commit SHA for pypi publish

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,7 +43,7 @@ jobs:
         # TODO: this is temporarily pointed at TestPyPI to validate the pipeline (starting with the v1.3.1 tag).
         # Remove the repository-url line below to switch to production PyPI for the v1.4.0 release.
         # This pinned action came from pypa/gh-action-pypi-publish@v1.14.2, releases can be found on https://github.com/pypa/gh-action-pypi-publish/releases
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
**What I did**

`pypi.yml` had the wrong commit SHA for `v1.14.2` of that action. Fix.
