### PR TITLE
Tag Docker image as `latest` on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,10 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Don't auto-tag `latest` here: whether a release is a pre-release is only decided
+          # later, manually, on the draft release. See docker-latest.yml for the `latest` tag.
+          flavor: |
+            latest=false
       # Set up Qemu for multi-arch build
       - name: Set up Qemu
         # This pinned action came from docker/setup-qemu-action@v3, releases can be found on https://github.com/docker/setup-qemu-action/releases

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,0 +1,37 @@
+name: docker-latest
+run-name: Point docker :latest at ${{ github.event.release.tag_name }}
+on:
+  release:
+    types: [released]
+
+# Defines three custom environment variables for the workflow. These are used for the Container registry domain, a name for the Docker image that this workflow builds, and the release tag to point `latest` at. Defining RELEASE_TAG here (rather than interpolating github.event.release.tag_name directly into a run: script) prevents shell script injection via a maliciously crafted tag name.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+jobs:
+  tag-latest:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        # This pinned action came from docker/login-action@v3, releases can be found on https://github.com/docker/login-action/releases
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Set up buildx, needed for the `docker buildx imagetools` command below
+      - name: Set up Docker Buildx
+        # This pinned action came from docker/setup-buildx-action@v3, releases can be found on https://github.com/docker/setup-buildx-action/releases
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
+      # Points the `latest` tag at the already-built, already-pushed multi-arch image for this
+      # release's tag, without rebuilding it.
+      - name: Tag image as latest
+        run: |
+          docker buildx imagetools create \
+            --tag "${REGISTRY}/${IMAGE_NAME}:latest" \
+            "${REGISTRY}/${IMAGE_NAME}:${RELEASE_TAG}"

--- a/docs/src/release_process.md
+++ b/docs/src/release_process.md
@@ -14,7 +14,7 @@ git push origin v1.0.0
 6. The tag push also triggers [the ci-pypi workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/pypi.yml), which builds and publishes the package to PyPI. This workflow waits for approval against the `pypi` environment's protection rule — open the workflow run in the Actions tab and approve the pending deployment to let it proceed.
 7. Open the draft release and fill in the different sections correctly.
 8. If this is not a production release, check the *Set as a pre-release* checkbox.
-9. Click the *Publish release* button.
+9. Click the *Publish release* button. This triggers [the docker-latest workflow](https://github.com/ethstaker/ethstaker-deposit-cli/actions/workflows/docker-latest.yml), which points the `latest` Docker tag at this release's image — unless it was checked as a pre-release in step 8, in which case `latest` is left untouched.
 10. Determine a new dev version number. You can try to guess the next version number to the best of your ability. This will always be subject to change. Add a `dev` identifier to the version number to clearly indicate this is a dev version number.
 11. Update `ethstaker_deposit/VERSION`'s content with a new dev version number. Commit this change to the main branch.
 


### PR DESCRIPTION
**What I did**

Docker images get created before release, and so even a pre-release is tagged `latest`

Move tagging the Docker image as `latest` into a separate workflow that triggers when a release is designated `Latest`, whether that happens from the draft or later with an edit.
