### PR TITLE
Rely on click's own SIGINT handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-        - click==8.1.8
+        - click>=8.5.1
         - eth-typing==5.1.0
         - eth-utils==5.1.0
         - pycryptodome==3.21.0

--- a/binary_tests/test_tty.exp
+++ b/binary_tests/test_tty.exp
@@ -9,7 +9,7 @@
 #   * the interactive language chooser accepts input
 #   * the internet-connectivity warning and its "press any key" pause
 #     (exercised only when online, skipped cleanly when offline)
-#   * Ctrl+C at a prompt aborts with "Aborted!" and exit code 1
+#   * Ctrl+C at a prompt aborts with exit code 1
 
 source [file join [file dirname [info script]] lib.exp]
 
@@ -104,7 +104,11 @@ puts "--- tty: Ctrl+C aborts at a prompt ---"
 spawn $env(BINARY) --language english --ignore_connectivity generate-mnemonic
 expect_or_fail {language of the mnemonic word list}
 send "\x03"
-expect_or_fail {Aborted}
+# Only the exit code is asserted, not the "Aborted!" message. A second interrupt
+# can land while click is writing that message, and click's contract is that a
+# late interrupt may lose the message but never the exit code.
+# See https://github.com/pallets/click/pull/3818 and
+# https://github.com/pallets/click/issues/3802.
 expect_eof
 set result [wait]
 set exit_code [lindex $result 3]

--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -122,9 +122,6 @@ def run() -> None:
     except (MultiLanguageError, ValueError, ValidationError) as e:
         click.echo(f"\nError: {e}\n", err=True)
         sys.exit(1)
-    except KeyboardInterrupt:
-        sys.stderr.write('Aborted!\n')
-        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "click>=8.4.2",
+    "click>=8.5.1",
     "eth-typing>=6.0.0",
     "eth-utils>=6.0.0",
     "pycryptodome>=3.23.0",

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -1,11 +1,11 @@
 import os
 import socket
+import sys
 
 import click
 import pytest
 from click.testing import CliRunner
 
-from ethstaker_deposit import deposit
 from ethstaker_deposit.deposit import check_connectivity, cli, run
 from tests.test_cli.helpers import clean_key_folder
 
@@ -151,20 +151,80 @@ def test_should_not_check_connectivity_with_non_interactive(monkeypatch) -> None
     clean_key_folder(my_folder_path)
 
 
-def test_run_handles_keyboard_interrupt_from_cli(monkeypatch, capsys) -> None:
-    # Simulates a KeyboardInterrupt escaping click's own Abort handling
-    # (see click's `except Abort:` block in `BaseCommand.main`), which can
-    # happen if a second interrupt fires while click is echoing "Aborted!".
-    def _mock_cli():
+class _RecordingStderr:
+    '''
+    A stderr stand-in that records what is written to it and can raise a second
+    KeyboardInterrupt from isatty(), simulating a Ctrl+C that lands while click
+    is reporting the abort for the first one.
+
+    click's echo() calls should_strip_ansi() -> isatty() before writing, and
+    click._compat.isatty() only catches Exception, so a KeyboardInterrupt raised
+    there escapes Command.main() entirely. That is where the traceback in
+    https://github.com/pallets/click/issues/3802 ended.
+
+    Counting only starts once arm() is called, so `interrupt_at` is relative to
+    the abort sequence rather than to any earlier stderr output from the CLI.
+    '''
+
+    def __init__(self, interrupt_at: int | None = None):
+        self.text = ''
+        self.interrupt_at = interrupt_at
+        self.isatty_calls = 0
+        self.armed = False
+
+    def arm(self) -> None:
+        self.armed = True
+
+    def isatty(self) -> bool:
+        if self.armed:
+            self.isatty_calls += 1
+            if self.isatty_calls == self.interrupt_at:
+                raise KeyboardInterrupt()
+        return False
+
+    def write(self, value: str) -> int:
+        self.text += value
+        return len(value)
+
+    def flush(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize('interrupt_at', [None, 1])
+def test_run_handles_keyboard_interrupt_at_prompt(monkeypatch, interrupt_at) -> None:
+    '''
+    Ctrl+C at the mnemonic language prompt must exit 1, even if a second
+    interrupt arrives while click writes "Aborted!". The message is best effort
+    once that happens, but the exit code is not.
+
+    This drives the real `cli` through `run()`: the interrupt is injected where a
+    real one lands (click's input function), not by replacing `cli` itself, so
+    click's own Abort handling is what is under test.
+    '''
+    stderr = _RecordingStderr(interrupt_at=interrupt_at)
+
+    def _interrupt_prompt(text: str) -> str:
+        stderr.arm()
         raise KeyboardInterrupt()
 
-    monkeypatch.setattr(deposit, 'cli', _mock_cli)
+    monkeypatch.setattr('click.termui.visible_prompt_func', _interrupt_prompt)
+    monkeypatch.setattr(sys, 'stderr', stderr)
+    monkeypatch.setattr(sys, 'argv', [
+        'deposit', '--language', 'english', '--ignore_connectivity', 'generate-mnemonic',
+    ])
 
-    with pytest.raises(SystemExit) as exc_info:
+    try:
         run()
+    except SystemExit as e:
+        exit_code = e.code
+    except KeyboardInterrupt:
+        pytest.fail('KeyboardInterrupt escaped click Command.main(); see pallets/click#3802')
+    else:
+        pytest.fail('run() returned without exiting')
 
-    assert exc_info.value.code == 1
-    assert 'Aborted!' in capsys.readouterr().err
+    assert exit_code == 1
+    if interrupt_at is None:
+        assert 'Aborted!' in stderr.text
 
 
 def test_should_not_check_connectivity_with_both_non_interactive_or_ignore_connectivity(monkeypatch) -> None:


### PR DESCRIPTION
**What I did**

Remove the work-around for click's race condition. Strengthen the unit test to actually test that, and not the presence of our workaround.

Requires click 8.5.1 or later. Keep in draft; rebase and enable tests when 8.5.1 is in our `main`

click's fix PR: https://github.com/pallets/click/pull/3818