### PR TITLE
Mypy strict optional

### DIFF
--- a/ethstaker_deposit/cli/exit_transaction_mnemonic.py
+++ b/ethstaker_deposit/cli/exit_transaction_mnemonic.py
@@ -111,7 +111,7 @@ def exit_transaction_mnemonic(
     with click.progressbar(length=num_keys, label=load_text(['msg_key_creation']),
                            show_percent=False, show_pos=True) as bar:
 
-        executor_kwargs = [{
+        executor_kwargs: list[dict[str, Any]] = [{
             'mnemonic': mnemonic,
             'mnemonic_password': mnemonic_password,
             'index': index,

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -251,13 +251,15 @@ class Credential:
         decryption_key = saved_keystore._get_decryption_key(password=password)
         return (decryption_key, saved_keystore.crypto.kdf.params['salt'])
 
-    def get_bls_to_execution_change(self, validator_index: int) -> SignedBLSToExecutionChange:
-        if self.withdrawal_address is None:
-            raise ValueError("The withdrawal address should NOT be empty.")
+    def _require_genesis_validators_root(self) -> bytes:
         if self.chain_setting.GENESIS_VALIDATORS_ROOT is None:
             raise ValidationError("The genesis validators root should NOT be empty "
                                   "for this chain to obtain the BLS to execution change.")
+        return self.chain_setting.GENESIS_VALIDATORS_ROOT
 
+    def get_bls_to_execution_change(self, validator_index: int) -> SignedBLSToExecutionChange:
+        if self.withdrawal_address is None:
+            raise ValueError("The withdrawal address should NOT be empty.")
         message = BLSToExecutionChange(  # type: ignore[no-untyped-call]
             validator_index=validator_index,
             from_bls_pubkey=self.withdrawal_pk,
@@ -265,7 +267,7 @@ class Credential:
         )
         domain = compute_bls_to_execution_change_domain(
             fork_version=self.chain_setting.GENESIS_FORK_VERSION,
-            genesis_validators_root=self.chain_setting.GENESIS_VALIDATORS_ROOT,
+            genesis_validators_root=self._require_genesis_validators_root(),
         )
         signing_root = compute_signing_root(message, domain)
         signature = bls.Sign(self.withdrawal_sk, signing_root)
@@ -293,7 +295,7 @@ class Credential:
         # metadata
         metadata: dict[str, Any] = {
             'network_name': self.chain_setting.NETWORK_NAME,
-            'genesis_validators_root': '0x' + self.chain_setting.GENESIS_VALIDATORS_ROOT.hex(),
+            'genesis_validators_root': '0x' + self._require_genesis_validators_root().hex(),
             'deposit_cli_version': DEPOSIT_CLI_VERSION,
         }
 

--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -64,7 +64,7 @@ commands = [
 class SortedGroup(click.Group):
 
     def list_commands(self, ctx: click.Context) -> list[str]:
-        return [x.name for x in commands]
+        return [x.name for x in commands if x.name is not None]
 
 
 @click.group(cls=SortedGroup)

--- a/ethstaker_deposit/settings.py
+++ b/ethstaker_deposit/settings.py
@@ -107,9 +107,9 @@ def get_devnet_chain_setting(network_name: str,
                              genesis_fork_version: str,
                              exit_fork_version: str,
                              genesis_validator_root: str | None,
-                             multiplier: int | None = 1,
-                             min_activation_amount: float | None = 32,
-                             min_deposit_amount: float | None = 1) -> BaseChainSetting:
+                             multiplier: int = 1,
+                             min_activation_amount: float = 32,
+                             min_deposit_amount: float = 1) -> BaseChainSetting:
 
     return BaseChainSetting(
         NETWORK_NAME=network_name,

--- a/ethstaker_deposit/utils/click.py
+++ b/ethstaker_deposit/utils/click.py
@@ -61,7 +61,7 @@ class JITOption(click.Option):
         self.prompt = _value_of(self.callable_prompt)
         return super().prompt_for_value(ctx)
 
-    def get_help_record(self, ctx: click.Context) -> tuple[str, str]:
+    def get_help_record(self, ctx: click.Context) -> tuple[str, str] | None:
         self.help = _value_of(self.callable_help)
         return super().get_help_record(ctx)
 
@@ -211,7 +211,7 @@ def captive_prompt_callback(
     confirmation_prompt: Callable[[], str] | None = None,
     confirmation_mismatch_msg: Callable[[], str] = lambda: '',
     hide_input: bool = False,
-    default: Callable[[], str] | str | None = None,
+    default: Callable[[], str | None] | str | None = None,
     prompt_if: Callable[[click.Context, Any, str], bool] | None = None,
     prompt_marker: str = '',
 ) -> Callable[[click.Context, str, str], Any]:

--- a/ethstaker_deposit/utils/crypto.py
+++ b/ethstaker_deposit/utils/crypto.py
@@ -40,7 +40,8 @@ def PBKDF2(*, password: bytes, salt: bytes, dklen: int, c: int, prf: str) -> byt
         '''
         raise ValueError("The PBKDF2 parameters chosen are not secure.")
     _hash = _sha256 if 'sha256' in prf else _sha512
-    res = _PBKDF2(password=password, salt=salt, dkLen=dklen, count=c, hmac_hash_module=_hash)  # type: ignore
+    # PyCryptodome's KDF.pyi types `password` as str; the runtime accepts bytes too.
+    res = _PBKDF2(password=password, salt=salt, dkLen=dklen, count=c, hmac_hash_module=_hash)  # type: ignore[arg-type]
     return res if isinstance(res, bytes) else res[0]  # PyCryptodome can return Tuple[bytes]
 
 

--- a/ethstaker_deposit/utils/exit_transaction.py
+++ b/ethstaker_deposit/utils/exit_transaction.py
@@ -3,6 +3,7 @@ import os
 from typing import Any
 from py_ecc.bls import G2ProofOfPossession as bls
 
+from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.settings import BaseChainSetting
 from ethstaker_deposit.utils.ssz import (
     SignedVoluntaryExit,
@@ -20,6 +21,10 @@ def exit_transaction_generation(
         signing_key: int,
         validator_index: int,
         epoch: int) -> SignedVoluntaryExit:
+    if chain_setting.GENESIS_VALIDATORS_ROOT is None:
+        raise ValidationError("The genesis validators root should NOT be empty "
+                              "for this chain to sign a voluntary validator exit message.")
+
     message = VoluntaryExit(  # type: ignore[no-untyped-call]
         epoch=epoch,
         validator_index=validator_index

--- a/ethstaker_deposit/utils/file_handling.py
+++ b/ethstaker_deposit/utils/file_handling.py
@@ -10,7 +10,7 @@ def resource_path(relative_path: str) -> str:
     into a resource path so it is available both when building binaries and running natively.
     """
     try:
-        base_path = sys._MEIPASS  # type: ignore
+        base_path: str = getattr(sys, '_MEIPASS')
     except Exception:
         base_path = os.path.abspath(".")
     return os.path.join(base_path, relative_path)

--- a/ethstaker_deposit/utils/intl.py
+++ b/ethstaker_deposit/utils/intl.py
@@ -1,6 +1,5 @@
 import inspect
 import difflib
-from functools import reduce
 import json
 from typing import Any
 from collections.abc import Iterable, Mapping, Sequence
@@ -21,7 +20,11 @@ def _get_from_dict(dataDict: dict[str, Any], mapList: Iterable[str]) -> str:
     Iterate nested dictionaries
     '''
     try:
-        ans = reduce(dict.get, mapList, dataDict)
+        # Unbound dict.get keeps the existing contract: a missing key yields None and a
+        # non-dict intermediate raises TypeError, both of which surface below as KeyError.
+        ans: Any = dataDict
+        for key in mapList:
+            ans = dict.get(ans, key)
         if not isinstance(ans, str):
             raise ValidationError('Incomplete')
         return ans

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -282,7 +282,8 @@ def validate_int_range(num: Any, low: int, high: int) -> int:
         raise ValidationError(load_text(['err_not_positive_integer']))
 
 
-def validate_withdrawal_address(cts: click.Context, param: Any, address: str, require: bool = False) -> HexAddress:
+def validate_withdrawal_address(ctx: click.Context | None, param: Any, address: str,
+                                require: bool = False) -> HexAddress | None:
     if address in ("", None):
         if require:
             raise ValidationError(load_text(['err_missing_address']))
@@ -297,7 +298,7 @@ def validate_withdrawal_address(cts: click.Context, param: Any, address: str, re
     return normalized_address
 
 
-def validate_yesno(ctx: click.Context, param: Any, value: str) -> bool:
+def validate_yesno(ctx: click.Context | None, param: Any, value: str) -> bool:
     '''
     Verifies that a value is part of the bool values accepted by click. The string values “1”, “true”,
     “t”, “yes”, “y”, and “on” convert to True. “0”, “false”, “f”, “no”, “n”, and “off” convert to False.
@@ -544,6 +545,10 @@ def validate_signed_exit(validator_index: str,
                          signature: str,
                          pubkey: str,
                          chain_setting: BaseChainSetting) -> bool:
+    if chain_setting.GENESIS_VALIDATORS_ROOT is None:
+        raise ValidationError(load_text(['missing_genesis_validators_root'],
+                                        func='validate_genesis_validators_root'))
+
     bls_pubkey = BLSPubkey(bytes.fromhex(pubkey))
     bls_signature = BLSSignature(decode_hex(signature))
     message = VoluntaryExit(  # type: ignore[no-untyped-call]
@@ -584,6 +589,10 @@ def validate_bls_to_execution_change_keystore(validator_index: str,
                                               signature: str,
                                               pubkey: str,
                                               chain_setting: BaseChainSetting) -> bool:
+    if chain_setting.GENESIS_VALIDATORS_ROOT is None:
+        raise ValidationError(load_text(['missing_genesis_validators_root'],
+                                        func='validate_genesis_validators_root'))
+
     bls_pubkey = BLSPubkey(bytes.fromhex(pubkey))
     bls_signature = BLSSignature(decode_hex(signature))
     message = BLSToExecutionChangeKeystore(  # type: ignore[no-untyped-call]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 warn_unused_ignores = True
 ignore_missing_imports = True
-strict_optional = False
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True

--- a/tests/test_key_handling/test_keystore.py
+++ b/tests/test_key_handling/test_keystore.py
@@ -12,7 +12,7 @@ from ethstaker_deposit.key_handling.keystore import (
 test_vector_password = '𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑'
 test_vector_secret = bytes.fromhex('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f')
 test_vector_folder = os.path.join(os.getcwd(), 'tests', 'test_key_handling', 'keystore_test_vectors')
-_, _, test_vector_files = next(os.walk(test_vector_folder))  # type: ignore
+test_vector_files = next(os.walk(test_vector_folder))[2]
 
 test_vector_keystores = [Keystore.from_file(os.path.join(test_vector_folder, f)) for f in test_vector_files]
 

--- a/tests/test_utils/test_validation_genesis_validators_root.py
+++ b/tests/test_utils/test_validation_genesis_validators_root.py
@@ -1,0 +1,76 @@
+import pytest
+
+from ethstaker_deposit.credentials import Credential
+from ethstaker_deposit.exceptions import ValidationError
+from ethstaker_deposit.settings import EphemerySetting, MainnetSetting
+from ethstaker_deposit.utils.exit_transaction import exit_transaction_generation
+from ethstaker_deposit.utils.validation import (
+    validate_bls_to_execution_change_keystore,
+    validate_genesis_validators_root,
+    validate_signed_exit,
+)
+
+
+MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+ADDRESS = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+
+# Ephemery deliberately carries no GENESIS_VALIDATORS_ROOT; the root changes with each reset.
+LOCALIZED = 'GENESIS_VALIDATORS_ROOT'
+HARDCODED = 'genesis validators root should NOT be empty'
+
+
+def _credential(chain_setting) -> Credential:
+    return Credential(
+        mnemonic=MNEMONIC,
+        mnemonic_password='',
+        index=0,
+        amount=32 * 10**9,
+        chain_setting=chain_setting,
+        hex_withdrawal_address=ADDRESS,
+    )
+
+
+def test_validate_genesis_validators_root_rejects_missing_root() -> None:
+    with pytest.raises(ValidationError, match=LOCALIZED):
+        validate_genesis_validators_root(EphemerySetting)
+
+
+def test_validate_genesis_validators_root_accepts_present_root() -> None:
+    assert validate_genesis_validators_root(MainnetSetting) is None
+
+
+def test_exit_transaction_generation_rejects_missing_root() -> None:
+    with pytest.raises(ValidationError, match=HARDCODED):
+        exit_transaction_generation(
+            chain_setting=EphemerySetting,
+            signing_key=_credential(EphemerySetting).signing_sk,
+            validator_index=7,
+            epoch=1,
+        )
+
+
+def test_validate_signed_exit_rejects_missing_root() -> None:
+    with pytest.raises(ValidationError, match=LOCALIZED):
+        validate_signed_exit(
+            validator_index='7',
+            epoch='1',
+            signature='0x' + '00' * 96,
+            pubkey='00' * 48,
+            chain_setting=EphemerySetting,
+        )
+
+
+def test_validate_bls_to_execution_change_keystore_rejects_missing_root() -> None:
+    with pytest.raises(ValidationError, match=LOCALIZED):
+        validate_bls_to_execution_change_keystore(
+            validator_index='7',
+            to_execution_address=ADDRESS,
+            signature='0x' + '00' * 96,
+            pubkey='00' * 48,
+            chain_setting=EphemerySetting,
+        )
+
+
+def test_get_bls_to_execution_change_dict_rejects_missing_root() -> None:
+    with pytest.raises(ValidationError, match=HARDCODED):
+        _credential(EphemerySetting).get_bls_to_execution_change_dict(validator_index=7)


### PR DESCRIPTION
**What I did**

Enable mypy's strict optional checks; introduce guards against `None` that were missing

Also remove as many type ignores as I can. Two upstream packages still need them: `py-ssz` broadly; and one issue with `pycryptodome`. Won't resolve until `eth-ssz-specs` for the one, and a new release with typing improvements for the other.

makes progress on #10 
