### PR TITLE
pre-commit Python dependencies match pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-        - click==8.1.8
-        - eth-typing==5.1.0
-        - eth-utils==5.1.0
-        - pycryptodome==3.21.0
-        - py-ecc==7.0.1
-        - ssz==0.5.1
+        - click>=8.4.2
+        - eth-typing>=6.0.0
+        - eth-utils>=6.0.0
+        - pycryptodome>=3.23.0
+        - py-ecc>=8.0.0
+        - ssz>=0.5.2
       files: ^ethstaker_deposit/
       args: [--config-file, mypy.ini]
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
**What I did**

`pre-commit` pinned dependencies to an exact version. Relax that so a `pre-commit clean` can bring in updates.

These will need to be updated manually when the floors in `pyproject.toml` change
