### PR TITLE
Fix the shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
     hooks:
     - id: check-json
       files: ^ethstaker_deposit/intl
--   repo: https://github.com/pre-commit/mirrors-shellcheck
-    rev: v0.11.0
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
     - id: shellcheck
       files: \.sh$


### PR DESCRIPTION
**What I did**

`https://github.com/pre-commit/mirrors-shellcheck` 404s. Replace with `https://github.com/shellcheck-py/shellcheck-py` to avoid the Docker dependency of `https://github.com/koalaman/shellcheck-precommit`
