### PR TITLE
Dependabot won't consider pydantic-core >= 2.47

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     cooldown:
       default-days: 7
     directory: "/"
+    ignore:
+      - dependency-name: "pydantic-core"
+        versions: [">=2.47"]
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
**What I did**

So that 2.46.5 can come in

Revert this commit when pydantic new release is ready and wants pydantic-core 2.48
